### PR TITLE
Fixed stepper_y positions and added BED_MESH_CALIBRATE in print_start

### DIFF
--- a/Firmware/skr_mini_e3_v2_config.cfg
+++ b/Firmware/skr_mini_e3_v2_config.cfg
@@ -76,9 +76,9 @@ microsteps: 32
 ## Sensorless endstop for Y
 #endstop_pin: tmc2209_stepper_y:virtual_endstop
 #homing_retract_dist: 0 # Uncomment this line too
-position_endstop: 250
-position_min: 0
-position_max: 250
+position_endstop: 232
+position_min: -25
+position_max: 232
 homing_speed: 70
 homing_positive_dir: true
 
@@ -340,6 +340,7 @@ gcode:
 gcode:
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
+    BED_MESH_CALIBRATE
     
     ##Purge Line Gcode
     #G92 E0;


### PR DESCRIPTION
Actual config file put X0 Y0 outside the bed. I talk about this here : https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/hymness1/Quickdraw_probe_Voron_Switchwire/Klipper_Macros#about-the-modded-keybak-mount-and-the-endstop-microswitch-located-at-z_min-or-sensorless-homing-at-z_min-and-y-travel

This fix should put Y0 on the bed, just over the 2 little holes often founds on flex sheets. The positions works for a BOM VSW with an LDO MK52 heated bed.

I also added a BED_MESH_CALIBRATE after initial homing in print_start. We can't really do without one over at VSW.