### PR TITLE
Add G90 to PRINT_START macro

### DIFF
--- a/Firmware/skr_mini_e3_v2_config.cfg
+++ b/Firmware/skr_mini_e3_v2_config.cfg
@@ -340,7 +340,7 @@ gcode:
 gcode:
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
-    
+    G90                            ; absolute positioning    
     ##Purge Line Gcode
     #G92 E0;
     #G90


### PR DESCRIPTION
Added G90 to PRINT_START macro to prevent errors, when printer is in relative mode.