### PR TITLE
Add temperature parameters to PRINT_START macro

### DIFF
--- a/Firmware/skr_mini_e3_v2_config.cfg
+++ b/Firmware/skr_mini_e3_v2_config.cfg
@@ -341,6 +341,12 @@ gcode:
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
     
+    # Temperature parameters from common superslicer profiles.
+    #{% set bed_temp = params.BED|default(60)|float %}
+    #{% set extruder_temp = params.EXTRUDER|default(190)|float %}
+    #M190 S{bed_temp}      ; Set the bed temp and wait
+    #M109 S{extruder_temp} ; Set extruder temp and wait
+    
     ##Purge Line Gcode
     #G92 E0;
     #G90

--- a/Firmware/skr_mini_e3_v3_config.cfg
+++ b/Firmware/skr_mini_e3_v3_config.cfg
@@ -341,6 +341,12 @@ gcode:
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
     
+    # Temperature parameters from common superslicer profiles.
+    #{% set bed_temp = params.BED|default(60)|float %}
+    #{% set extruder_temp = params.EXTRUDER|default(190)|float %}
+    #M190 S{bed_temp}      ; Set the bed temp and wait
+    #M109 S{extruder_temp} ; Set extruder temp and wait
+    
     ##Purge Line Gcode
     #G92 E0;
     #G90


### PR DESCRIPTION
This updates the SKR mini e3 klipper configurations to include bed and extruder temperature parameters for the PRINT_START macro as called by [slic3r-profiles](https://github.com/slic3r/slic3r-profiles/blob/be9eda0bbf93ff217ad03606b0f9843aba145fa8/Voron.ini#L220).