### PR TITLE
Added diag_pin to Y sensorless homing config example.

### DIFF
--- a/Firmware/skr_mini_e3_v2_config.cfg
+++ b/Firmware/skr_mini_e3_v2_config.cfg
@@ -76,6 +76,7 @@ microsteps: 32
 ## Sensorless endstop for Y
 #endstop_pin: tmc2209_stepper_y:virtual_endstop
 #homing_retract_dist: 0 # Uncomment this line too
+#diag_pin: ^PC1 # Uncomment this line too
 position_endstop: 250
 position_min: 0
 position_max: 250


### PR DESCRIPTION
Example config is missing required diag_pin.  Required some tracking down, confirmed working.